### PR TITLE
Rolling deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ else
 endif
 
 init:
-	$(eval export ECR_REPO_NAME=fb-av)
 	$(eval export ECR_REPO_URL=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-av)
 
 # install aws cli w/o sudo
@@ -40,16 +39,15 @@ install_build_dependencies: init
 	$(eval export PATH=${PATH}:${HOME}/.local/bin/)
 
 
-# Needs ECR_REPO_NAME & ECR_REPO_URL env vars
 build: install_build_dependencies
-	docker build -t ${ECR_REPO_NAME}:latest-${env_stub} -f ./Dockerfile . && \
-		docker tag ${ECR_REPO_NAME}:latest-${env_stub} ${ECR_REPO_URL}:latest-${env_stub}
+	docker build -t ${ECR_REPO_URL}:latest-${env_stub} -t ${ECR_REPO_URL}:${CIRCLE_SHA1} -f ./Dockerfile .
 
 login: init
 	@eval $(shell aws ecr get-login --no-include-email --region eu-west-2)
 
 push: login
 	docker push ${ECR_REPO_URL}:latest-${env_stub}
+	docker push ${ECR_REPO_URL}:${CIRCLE_SHA1} #multiple tags in ECR can only be done by pushing twice
 
 build_and_push: build push
 

--- a/deploy/fb-av-chart/templates/deployment.yaml
+++ b/deploy/fb-av-chart/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: "formbuilder-av-{{ .Values.environmentName }}"
       containers:
       - name: "fb-av-{{ .Values.environmentName }}"
-        image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-av:latest-{{ .Values.platformEnv }}"
+        image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-av:{{ .Values.circleSha1 }}"
         imagePullPolicy: Always
         resources:
           requests:

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "homepage": "https://github.com/ministryofjustice/fb-av",
   "dependencies": {},
   "devDependencies": {
-    "@ministryofjustice/fb-deploy-utils": "^1.0.6"
+    "@ministryofjustice/fb-deploy-utils": "^1.0.10"
   }
 }

--- a/scripts/circleci_deploy.sh
+++ b/scripts/circleci_deploy.sh
@@ -20,7 +20,4 @@ echo "kubectl use circleci context"
 kubectl config use-context "circleci_${environment_name}_${deployment_name}"
 
 echo "apply kubernetes changes to ${environment_name} ${deployment_name}"
-./scripts/deploy_platform.sh -p $environment_name -d $deployment_name
-
-echo "delete pods in ${environment_name} ${deployment_name}"
-./scripts/restart_platform_pods.sh -p $environment_name -d $deployment_name -c "circleci_${environment_name}_${deployment_name}"
+./scripts/deploy_platform.sh -p $environment_name -d $deployment_name -s $CIRCLE_SHA1

--- a/scripts/restart_platform_pods.sh
+++ b/scripts/restart_platform_pods.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-FB_APPLICATION='fb-av' node_modules/\@ministryofjustice/fb-deploy-utils/bin/restart_platform_pods.sh $@


### PR DESCRIPTION
Instead of manually deleting pods (resulting in downtime), use kubernetes
built-in rolling deployments.  This requires a dynamic tag on the container
image that can be referred to by the Helm deployment.yaml file.

By simply using a tag like latest, that never changes, kubernetes won't pick up
that anything has changed and not deploy.