### PR TITLE
Use AWS ECR repo for image in test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,10 @@ jobs:
   build_and_deploy_to_test:
     working_directory: ~/circle/git/fb-av
     docker:
-      - image: asmega/fb-builder:latest
+      - image: $AWS_ECR_ACCOUNT_URL
+        aws_auth:
+          aws_access_key_id: $AWS_ACCESS_KEY_ID
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
We no longer want to use the personal repo on Dockerhub