### PR TITLE
Install CA certificates when building container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION main contrib non-fr
     echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION-updates main contrib non-free" >> /etc/apt/sources.list && \
     echo "deb http://security.debian.org/ $DEBIAN_VERSION/updates main contrib non-free" >> /etc/apt/sources.list && \
     apt-get update && \
+    apt-get install -y ca-certificates && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y -qq \
         clamav \
         clamav-daemon \


### PR DESCRIPTION
The freshclam virus definition updates were failing with the following message: `Problem with the SSL CA cert (path? access rights?)`.

The CA certs were not there. Install them during the container build process.

https://trello.com/c/508CY04g/630-update-clamav-virus-db