### PR TITLE
Update kubernetes resources

### DIFF
--- a/deploy/fb-av-chart/templates/deployment.yaml
+++ b/deploy/fb-av-chart/templates/deployment.yaml
@@ -1,10 +1,13 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "fb-av-{{ .Values.environmentName }}"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: "fb-av-{{ .Values.environmentName }}"
   template:
     metadata:
       labels:


### PR DESCRIPTION
Kubernetes has been upgraded to 1.16. These changes are required for the resources to continue working.

Followed the guide here:

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/apiversion-changes-k8s-1-16.html#resources-deployed-using-helm-charts

https://trello.com/c/w8d8G6RM/696-cloud-platform-kubernetes-update