### PR TITLE
Disable pentest step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,10 +63,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - build_and_deploy_to_pentest:
-          filters:
-            branches:
-              only: master
       - build_and_deploy_to_test:
           filters:
             branches:


### PR DESCRIPTION
We do not want to keep changing the pentest environment while testing is ongoing. We can put the step back should we need to deploy out to it.