### PR TITLE
Increase memory limit

### DIFF
--- a/deploy/fb-av-chart/templates/deployment.yaml
+++ b/deploy/fb-av-chart/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
             memory: "1024Mi"
           limits:
             cpu: "150m"
-            memory: "1500Mi"
+            memory: "2500Mi"
         ports:
           - containerPort: 3310
         # non-secret env vars


### PR DESCRIPTION
We are having instances of the AV container restarting with error `Reason:       OOMKilled`, which means it has run out of memory.

Give a bit more memory to the pod to see if it helps with the constant restarting.