### PR TITLE
Increase the memory on pod

### DIFF
--- a/deploy/fb-av-chart/templates/deployment.yaml
+++ b/deploy/fb-av-chart/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
             memory: "1024Mi"
           limits:
             cpu: "150m"
-            memory: "2500Mi"
+            memory: "3500Mi"
         ports:
           - containerPort: 3310
         # non-secret env vars


### PR DESCRIPTION
[Trello Card](https://trello.com/c/bnUYdFAT/802-increase-memory-of-antivirus)

The Grafana is showing spikes above the current limit. 

On the short term will increase until we further investigate why is happening.