### PR TITLE
Fix day formatting in clamav check script

### DIFF
--- a/scripts/clamav_check.rb
+++ b/scripts/clamav_check.rb
@@ -19,11 +19,14 @@ scheduler = Rufus::Scheduler.new
 scheduler.cron '50 15 * * *' do
   logger.info('Starting check')
 
-  today = Date.today.strftime("%a %b %d")
+  today = Date.today
+  day_format = today.day < 10 ? ' %-d' : '%d'
+  formatted_today = today.strftime("%a %b #{day_format}")
+
   begin
     todays_log_lines = File.read(FRESHCLAM_LOG_FILE)
                            .split("\n")
-                           .select { |line| line.include?(today) }
+                           .select { |line| line.include?(formatted_today) }
 
     unless todays_log_lines.find { |line| line.match(BYTECODE) }
       raise(StandardError, "Bytecode database failed to update -> #{Time.now}")


### PR DESCRIPTION
The check that the clamav database has been updated correctly on a daily basis has been failing consistently. The database itself has been updated fine but the check doesn't work on single digit days.

For days with double digits the clamav log prints

`Mon Aug 31 18:08:43 2020`

However for days with a single digit the clamav log prints

`Wed Sep  9 17:30:04 2020`

There is a double space between the month and day :(

On days which only have a single digit we need to correctly format the date in order to match the log line.