### PR TITLE
Notify slack on deployment failures and successes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2
+version: 2.1
+orbs:
+  slack: circleci/slack@3.4.2
+
 jobs:
   build_and_deploy_to_test:
     working_directory: ~/circle/git/fb-av
@@ -42,6 +45,11 @@ jobs:
             DEPLOYMENT_ENV: production
             K8S_NAMESPACE: formbuilder-platform-test-production
           command: './deploy-scripts/bin/deploy'
+      - slack/status: &slack_status
+          fail_only: true
+          only_for_branches: master
+          failure_message: ":facepalm:  Failed job $CIRCLE_JOB  :homer-disappear:"
+          include_job_number_field: false
   acceptance_tests:
     docker: *ecr_image
     resource_class: large
@@ -51,6 +59,7 @@ jobs:
       - run:
           name: Run acceptance tests
           command: './deploy-scripts/bin/acceptance_tests'
+      - slack/status: *slack_status
   build_and_deploy_to_live:
     working_directory: ~/circle/git/fb-av
     docker: *ecr_image
@@ -81,6 +90,11 @@ jobs:
             DEPLOYMENT_ENV: production
             K8S_NAMESPACE: formbuilder-platform-live-production
           command: './deploy-scripts/bin/deploy'
+      - slack/status:
+          only_for_branches: master
+          success_message: ":rocket:  Successfully deployed to Live  :guitar:"
+          failure_message: ":alert:  Failed to deploy to Live  :try_not_to_cry:"
+          include_job_number_field: false
 
 workflows:
   version: 2
@@ -98,6 +112,11 @@ workflows:
             branches:
               only:
                 - master
+      - slack/approval-notification:
+          message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
+          include_job_number_field: false
+          requires:
+            - acceptance_tests
       - confirm_live_deploy:
           type: approval
           requires:


### PR DESCRIPTION
Moving the acceptance tests into each deployment has removed the notification that happens when they fail as it's not actually the circleci job that is running anymore.

We require notifications to be sent to the #form-builder-deployments channel on failure of acceptance tests.

Also on failure to deploy to production.

Also on a successful deploy to production

https://trello.com/c/myuOzEs3/933-notify-slack-when-deployments-fail-succeed