### PR TITLE
Auto --yes apt-upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION main contrib non-fr
     echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION-updates main contrib non-free" >> /etc/apt/sources.list && \
     echo "deb http://security.debian.org/ $DEBIAN_VERSION/updates main contrib non-free" >> /etc/apt/sources.list && \
     apt-get update && \
-    apt-get upgrade && \
+    apt-get upgrade -y && \
     apt-get install ruby-full -y && \
     gem install sentry-raven && \
     gem install rufus-scheduler && \


### PR DESCRIPTION
If we are going to automatically YOLO any `apt-upgrade` commands then we have to pass `-y` otherwise the builds fail.