### PR TITLE
Fix monitoring for the bytecode av db

### DIFF
--- a/scripts/clamav_check.rb
+++ b/scripts/clamav_check.rb
@@ -10,9 +10,9 @@ Raven.configure do |config|
 end
 
 FRESHCLAM_LOG_FILE = '/var/log/clamav/freshclam.log'.freeze
-BYTECODE = /bytecode.cvd (database is up to date|updated)/.freeze
+BYTECODE = /(bytecode.cld|bytecode.cvd) (database is up to date|updated)/.freeze
 DAILY = /(daily.cld|daily.cvd) (database is up to date|updated)/.freeze
-MAIN = /main.cvd (database is up to date|updated)/.freeze
+MAIN = /(main.cld|main.cvd) (database is up to date|updated)/.freeze
 
 scheduler = Rufus::Scheduler.new
 


### PR DESCRIPTION
the bytecode.cvd has changed to bytecode.cld so the check now supports
both of them