### PR TITLE
Fix ClamAV database issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,25 +114,26 @@ workflows:
             branches:
               only:
                 - master
-      - acceptance_tests:
-          requires:
-            - build_and_deploy_to_test
-          filters:
-            branches:
-              only:
-                - master
-      - slack/approval-notification:
-          message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
-          include_job_number_field: false
-          requires:
-            - acceptance_tests
-      - confirm_live_deploy:
-          type: approval
-          requires:
-            - acceptance_tests
-      - build_and_deploy_to_live:
-          requires:
-            - confirm_live_deploy
-      - smoke_tests:
-          requires:
-            - build_and_deploy_to_live
+                - fix/circleci
+      # - acceptance_tests:
+      #     requires:
+      #       - build_and_deploy_to_test
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      # - slack/approval-notification:
+      #     message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
+      #     include_job_number_field: false
+      #     requires:
+      #       - acceptance_tests
+      # - confirm_live_deploy:
+      #     type: approval
+      #     requires:
+      #       - acceptance_tests
+      # - build_and_deploy_to_live:
+      #     requires:
+      #       - confirm_live_deploy
+      # - smoke_tests:
+      #     requires:
+      #       - build_and_deploy_to_live

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,26 +114,25 @@ workflows:
             branches:
               only:
                 - master
-                - fix/circleci
-      # - acceptance_tests:
-      #     requires:
-      #       - build_and_deploy_to_test
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      # - slack/approval-notification:
-      #     message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
-      #     include_job_number_field: false
-      #     requires:
-      #       - acceptance_tests
-      # - confirm_live_deploy:
-      #     type: approval
-      #     requires:
-      #       - acceptance_tests
-      # - build_and_deploy_to_live:
-      #     requires:
-      #       - confirm_live_deploy
-      # - smoke_tests:
-      #     requires:
-      #       - build_and_deploy_to_live
+      - acceptance_tests:
+          requires:
+            - build_and_deploy_to_test
+          filters:
+            branches:
+              only:
+                - master
+      - slack/approval-notification:
+          message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
+          include_job_number_field: false
+          requires:
+            - acceptance_tests
+      - confirm_live_deploy:
+          type: approval
+          requires:
+            - acceptance_tests
+      - build_and_deploy_to_live:
+          requires:
+            - confirm_live_deploy
+      - smoke_tests:
+          requires:
+            - build_and_deploy_to_live

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,16 @@ RUN echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION main contrib non-fr
     rm -rf /var/lib/apt/lists/*
 
 # initial update of av databases
-RUN wget -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd && \
-    wget -O /var/lib/clamav/daily.cvd http://database.clamav.net/daily.cvd && \
-    wget -O /var/lib/clamav/bytecode.cvd http://database.clamav.net/bytecode.cvd && \
-    chown clamav:clamav /var/lib/clamav/*.cvd
+# RUN wget -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd && \
+#     wget -O /var/lib/clamav/daily.cvd http://database.clamav.net/daily.cvd && \
+#     wget -O /var/lib/clamav/bytecode.cvd http://database.clamav.net/bytecode.cvd && \
+#     chown clamav:clamav /var/lib/clamav/*.cvd
+
+COPY ./main.cvd  /var/lib/clamav/main.cvd
+COPY ./daily.cvd  /var/lib/clamav/daily.cvd
+COPY ./bytecode.cvd  /var/lib/clamav/bytecode.cvd
+
+RUN chown clamav:clamav /var/lib/clamav/*.cvd
 
 # permission juggling
 RUN mkdir /var/run/clamav && \
@@ -35,7 +41,8 @@ RUN mkdir /var/run/clamav && \
 # av configuration update
 RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
     echo "TCPSocket 3310" >> /etc/clamav/clamd.conf && \
-    sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
+    sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf && \
+    echo "SafeBrowsing no" >> /etc/clamav/freshclam.conf
 
 # monitor clamav updates
 ADD scripts/clamav_check.rb /

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,15 +21,9 @@ RUN echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION main contrib non-fr
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# initial update of av databases
-# RUN wget -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd && \
-#     wget -O /var/lib/clamav/daily.cvd http://database.clamav.net/daily.cvd && \
-#     wget -O /var/lib/clamav/bytecode.cvd http://database.clamav.net/bytecode.cvd && \
-#     chown clamav:clamav /var/lib/clamav/*.cvd
-
-COPY ./main.cvd  /var/lib/clamav/main.cvd
-COPY ./daily.cvd  /var/lib/clamav/daily.cvd
-COPY ./bytecode.cvd  /var/lib/clamav/bytecode.cvd
+COPY --from=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-av:base /var/lib/clamav/main.cvd /var/lib/clamav/main.cvd
+COPY --from=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-av:base /var/lib/clamav/daily.cvd /var/lib/clamav/daily.cvd
+COPY --from=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-av:base /var/lib/clamav/bytecode.cvd /var/lib/clamav/bytecode.cvd
 
 RUN chown clamav:clamav /var/lib/clamav/*.cvd
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ TCPAddr localhost # or wherever you setup this container
 
 copied from https://github.com/mko-x/docker-clamav
 
+ClamAV have databases that can be downloaded manually, these can be found here:
+- http://database.clamav.net/main.cvd
+- http://database.clamav.net/daily.cvd
+- http://database.clamav.net/bytecode.cvd
+
+The ClamAV moderators limited the ability to download these files via ways such as `wget` and `curl` due the enormous number of daily downloads, more details [here](https://www.mail-archive.com/clamav-users@lists.clamav.net/msg49810.html).
+
+As a result, we have built a ECR image that holds the 3 files we require, `main.cvd`, `daily.cvd` and `bytecode.cvd`.
+The [Dockerfile](Dockerfile) copies these 3 files from the image, freshclam should update these databases in the background, however, any issues with the clamav databases might be resolved by manually downloading the files and updating the `fb-av:base` ECR image.
+
 ## Run Locally
 `docker run -p 3310:3310 [image reference]`
 


### PR DESCRIPTION
### Add safebrowsing
ClamAV has removed the ability to download the safebrowsing.cvd, as a result we need to ensure SafeBrowsing is equal to 'no'.
This is outlined in this issue: mko-x/docker-clamav#103

### Copy ClamAV database files from ECR image
ClamAV have limited the download of main.cvd, daily.cvd and bytecode.cvd files, as well as limiting the use of wget, see:
https://www.mail-archive.com/clamav-users@lists.clamav.net/msg49810.html
To get around this, we have built an ECR image that holds these three files. The Dockerfile copies these files from the ECR image.

### Update Readme

Co-authored by: Brendan Butler <brendan.butler@digital.justice.gov.uk>
Co-authored by: Matt Tei <matt.tei@digital.justice.gov.uk>
Co-authored by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>