### PR TITLE
Update clamav check script to capture up-to-date string

### DIFF
--- a/scripts/clamav_check.rb
+++ b/scripts/clamav_check.rb
@@ -11,9 +11,9 @@ end
 
 FRESHCLAM_LOG_FILE = '/var/log/clamav/freshclam.log'.freeze
 UPDATE_TYPES = {
-  bytecode: /(bytecode.cld|bytecode.cvd) (database is up to date|updated)/,
-  daily: /(daily.cld|daily.cvd) (database is up to date|updated)/,
-  main: /(main.cld|main.cvd) (database is up to date|updated)/
+  bytecode: /(bytecode.cld|bytecode.cvd) (database is (up-to-date|updated|up to date))/,
+  daily: /(daily.cld|daily.cvd) (database is (up-to-date|updated|up to date))/,
+  main: /(main.cld|main.cvd) (database is (up-to-date|updated|up to date))/
 }
 
 scheduler = Rufus::Scheduler.new


### PR DESCRIPTION
The string in the log has changed again to be up-to-date.

Adjust the script to have three separate capture groups for the
different variants that we have seen in the logs.