### PR TITLE
Configure rolling update strategy for deployments

### DIFF
--- a/deploy/fb-av-chart/templates/deployment.yaml
+++ b/deploy/fb-av-chart/templates/deployment.yaml
@@ -5,6 +5,11 @@ metadata:
   name: "fb-av-{{ .Values.environmentName }}"
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0%
   selector:
     matchLabels:
       app: "fb-av-{{ .Values.environmentName }}"


### PR DESCRIPTION
This explicitly sets the strategy for the deployments to be a rolling
update.

maxSurge: 100% means that a complete additional copy of the deployment will
be created before any of the old pods are terminated

maxUnavailable: 0% means the cluster will not allow any containers to be
unavailable during deployment