### PR TITLE
Bump faraday gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     concurrent-ruby (1.1.6)
     et-orbi (1.2.4)
       tzinfo
-    faraday (1.0.1)
+    faraday (1.9.3)
       multipart-post (>= 1.2, < 3)
     fugit (1.3.6)
       et-orbi (~> 1.1, >= 1.1.8)


### PR DESCRIPTION
Deployment error `The last version of faraday (>= 1.0) to support your Ruby & RubyGems was 1.9.3.`
Bumping faraday to 1.9.3 to fix the issue.

a Please enter the commit message for your changes. Lines starting