### PR TITLE
Build issue during deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION main contrib non-fr
     apt-get update && \
     apt-get upgrade -y && \
     apt-get install ruby-full -y && \
+    gem install faraday -v >= 1.9.3 && \
     gem install sentry-raven && \
     gem install rufus-scheduler && \
     apt-get install -y ca-certificates && \


### PR DESCRIPTION
`ERROR:  Error installing sentry-raven:`

Forced the gem install within the Dockerfile to pick the version or
above that is needed.