### PR TITLE
Cleanup old deploy scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,22 +30,6 @@ jobs:
             ENVIRONMENT_NAME: test
           command: './deploy-scripts/bin/build'
       - run:
-          name: deploy to test dev
-          environment:
-            APPLICATION_NAME: fb-av
-            PLATFORM_ENV: test
-            DEPLOYMENT_ENV: dev
-            K8S_NAMESPACE: formbuilder-platform-test-dev
-          command: './deploy-scripts/bin/deploy'
-      - run:
-          name: deploy to test production
-          environment:
-            APPLICATION_NAME: fb-av
-            PLATFORM_ENV: test
-            DEPLOYMENT_ENV: production
-            K8S_NAMESPACE: formbuilder-platform-test-production
-          command: './deploy-scripts/bin/deploy'
-      - run:
           name: deploy to test dev in EKS
           environment:
             APPLICATION_NAME: fb-av
@@ -90,22 +74,6 @@ jobs:
           environment:
             ENVIRONMENT_NAME: live
           command: './deploy-scripts/bin/build'
-      - run:
-          name: deploy to live dev
-          environment:
-            APPLICATION_NAME: fb-av
-            PLATFORM_ENV: live
-            DEPLOYMENT_ENV: dev
-            K8S_NAMESPACE: formbuilder-platform-live-dev
-          command: './deploy-scripts/bin/deploy'
-      - run:
-          name: deploy to live production
-          environment:
-            APPLICATION_NAME: fb-av
-            PLATFORM_ENV: live
-            DEPLOYMENT_ENV: production
-            K8S_NAMESPACE: formbuilder-platform-live-production
-          command: './deploy-scripts/bin/deploy'
       - run:
           name: deploy to live dev in EKS
           environment:


### PR DESCRIPTION
These relate to the old ECR cluster, we no longer require them as we have now migrated to the EKS cluster.