### PR TITLE
Update fb-av for circle ci secret rotation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,44 +155,43 @@ workflows:
             branches:
               only:
                 - master
-                - update-circleci
       - deploy_to_test:
           context: *context
           requires:
             - build_image
-      # - deploy_to_saas_test:
-      #     context: *context
+      - deploy_to_saas_test:
+          context: *context
+          requires:
+            - build_image
+      # - acceptance_tests:
       #     requires:
-      #       - build_image
-      # # - acceptance_tests:
-      # #     requires:
-      # #       - deploy_to_test
-      # #       - deploy_to_saas_test
-      # #     filters:
-      # #       branches:
-      # #         only:
-      # #           - master
-      # - slack/approval-notification:
-      #     message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
-      #     include_job_number_field: false
-      #     requires:
-      #       # - acceptance_tests
       #       - deploy_to_test
       #       - deploy_to_saas_test
-      # - confirm_live_deploy:
-      #     type: approval
-      #     requires:
-      #       # - acceptance_tests
-      #       - deploy_to_test
-      #       - deploy_to_saas_test
-      # - deploy_to_live:
-      #     context: *context
-      #     requires:
-      #       - confirm_live_deploy
-      # - deploy_to_saas_live:
-      #     context: *context
-      #     requires:
-      #       - confirm_live_deploy
-      # - smoke_tests:
-      #     requires:
-      #       - deploy_to_live
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      - slack/approval-notification:
+          message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
+          include_job_number_field: false
+          requires:
+            # - acceptance_tests
+            - deploy_to_test
+            - deploy_to_saas_test
+      - confirm_live_deploy:
+          type: approval
+          requires:
+            # - acceptance_tests
+            - deploy_to_test
+            - deploy_to_saas_test
+      - deploy_to_live:
+          context: *context
+          requires:
+            - confirm_live_deploy
+      - deploy_to_saas_live:
+          context: *context
+          requires:
+            - confirm_live_deploy
+      - smoke_tests:
+          requires:
+            - deploy_to_live

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,12 @@ jobs:
       - setup_remote_docker
       - add_ssh_keys: &ssh_keys
           fingerprints:
-            - "6d:4e:f2:a6:5b:d8:59:b7:6b:3f:be:20:6b:68:1f:96"
+            - db:58:12:22:b9:f9:7d:b3:97:71:c2:a4:a8:1e:a1:95
       - run: &base_environment_variables
           name: Setup base environment variable
           command: |
             echo "export BUILD_SHA=$CIRCLE_SHA1" >> $BASH_ENV
-            echo "export SSH_FILE_FOR_SECRETS=~/.ssh/id_rsa_6d4ef2a65bd859b76b3fbe206b681f96" >> $BASH_ENV
+            echo "export SSH_FILE_FOR_SECRETS=~/.ssh/id_rsa_db581222b9f97db39771c2a4a81ea195" >> $BASH_ENV
       - run: &deploy_scripts
           name: cloning deploy scripts
           command: 'git clone git@github.com:ministryofjustice/fb-deploy.git deploy-scripts'
@@ -148,14 +148,19 @@ workflows:
   build:
     jobs:
       - build_image:
+          context: &context
+            - moj-forms
+            - moj-forms-platform-apps
           filters:
             branches:
               only:
                 - master
       - deploy_to_test:
+          context: *context
           requires:
             - build_image
       - deploy_to_saas_test:
+          context: *context
           requires:
             - build_image
       # - acceptance_tests:
@@ -180,9 +185,11 @@ workflows:
             - deploy_to_test
             - deploy_to_saas_test
       - deploy_to_live:
+          context: *context
           requires:
             - confirm_live_deploy
       - deploy_to_saas_live:
+          context: *context
           requires:
             - confirm_live_deploy
       - smoke_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,7 @@ workflows:
             branches:
               only:
                 - master
+                - update-circleci
       - deploy_to_test:
           context: *context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,43 +155,44 @@ workflows:
             branches:
               only:
                 - master
+                - update-circleci
       - deploy_to_test:
           context: *context
           requires:
             - build_image
-      - deploy_to_saas_test:
-          context: *context
-          requires:
-            - build_image
-      # - acceptance_tests:
+      # - deploy_to_saas_test:
+      #     context: *context
       #     requires:
+      #       - build_image
+      # # - acceptance_tests:
+      # #     requires:
+      # #       - deploy_to_test
+      # #       - deploy_to_saas_test
+      # #     filters:
+      # #       branches:
+      # #         only:
+      # #           - master
+      # - slack/approval-notification:
+      #     message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
+      #     include_job_number_field: false
+      #     requires:
+      #       # - acceptance_tests
       #       - deploy_to_test
       #       - deploy_to_saas_test
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      - slack/approval-notification:
-          message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
-          include_job_number_field: false
-          requires:
-            # - acceptance_tests
-            - deploy_to_test
-            - deploy_to_saas_test
-      - confirm_live_deploy:
-          type: approval
-          requires:
-            # - acceptance_tests
-            - deploy_to_test
-            - deploy_to_saas_test
-      - deploy_to_live:
-          context: *context
-          requires:
-            - confirm_live_deploy
-      - deploy_to_saas_live:
-          context: *context
-          requires:
-            - confirm_live_deploy
-      - smoke_tests:
-          requires:
-            - deploy_to_live
+      # - confirm_live_deploy:
+      #     type: approval
+      #     requires:
+      #       # - acceptance_tests
+      #       - deploy_to_test
+      #       - deploy_to_saas_test
+      # - deploy_to_live:
+      #     context: *context
+      #     requires:
+      #       - confirm_live_deploy
+      # - deploy_to_saas_live:
+      #     context: *context
+      #     requires:
+      #       - confirm_live_deploy
+      # - smoke_tests:
+      #     requires:
+      #       - deploy_to_live

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,39 +160,39 @@ workflows:
           context: *context
           requires:
             - build_image
-      - deploy_to_saas_test:
-          context: *context
-          requires:
-            - build_image
-      # - acceptance_tests:
+      # - deploy_to_saas_test:
+      #     context: *context
       #     requires:
+      #       - build_image
+      # # - acceptance_tests:
+      # #     requires:
+      # #       - deploy_to_test
+      # #       - deploy_to_saas_test
+      # #     filters:
+      # #       branches:
+      # #         only:
+      # #           - master
+      # - slack/approval-notification:
+      #     message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
+      #     include_job_number_field: false
+      #     requires:
+      #       # - acceptance_tests
       #       - deploy_to_test
       #       - deploy_to_saas_test
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      - slack/approval-notification:
-          message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
-          include_job_number_field: false
-          requires:
-            # - acceptance_tests
-            - deploy_to_test
-            - deploy_to_saas_test
-      - confirm_live_deploy:
-          type: approval
-          requires:
-            # - acceptance_tests
-            - deploy_to_test
-            - deploy_to_saas_test
-      - deploy_to_live:
-          context: *context
-          requires:
-            - confirm_live_deploy
-      - deploy_to_saas_live:
-          context: *context
-          requires:
-            - confirm_live_deploy
-      - smoke_tests:
-          requires:
-            - deploy_to_live
+      # - confirm_live_deploy:
+      #     type: approval
+      #     requires:
+      #       # - acceptance_tests
+      #       - deploy_to_test
+      #       - deploy_to_saas_test
+      # - deploy_to_live:
+      #     context: *context
+      #     requires:
+      #       - confirm_live_deploy
+      # - deploy_to_saas_live:
+      #     context: *context
+      #     requires:
+      #       - confirm_live_deploy
+      # - smoke_tests:
+      #     requires:
+      #       - deploy_to_live

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION main contrib non-fr
 # COPY --from=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-av:base /var/lib/clamav/daily.cvd /var/lib/clamav/daily.cvd
 # COPY --from=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-av:base /var/lib/clamav/bytecode.cvd /var/lib/clamav/bytecode.cvd
 
-RUN chown clamav:clamav /var/lib/clamav/*.cvd
+# RUN chown clamav:clamav /var/lib/clamav/*.cvd
 
 # permission juggling
 RUN mkdir /var/run/clamav && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
 
 # monitor clamav updates
 ADD scripts/clamav_check.rb /
+# add the probe script
+ADD readiness_probe.sh /
 
 # volume provision
 VOLUME ["/var/lib/clamav"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,9 @@ RUN echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION main contrib non-fr
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-av:base /var/lib/clamav/main.cvd /var/lib/clamav/main.cvd
-COPY --from=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-av:base /var/lib/clamav/daily.cvd /var/lib/clamav/daily.cvd
-COPY --from=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-av:base /var/lib/clamav/bytecode.cvd /var/lib/clamav/bytecode.cvd
+# COPY --from=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-av:base /var/lib/clamav/main.cvd /var/lib/clamav/main.cvd
+# COPY --from=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-av:base /var/lib/clamav/daily.cvd /var/lib/clamav/daily.cvd
+# COPY --from=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-av:base /var/lib/clamav/bytecode.cvd /var/lib/clamav/bytecode.cvd
 
 RUN chown clamav:clamav /var/lib/clamav/*.cvd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,6 @@ RUN echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION main contrib non-fr
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# COPY --from=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-av:base /var/lib/clamav/main.cvd /var/lib/clamav/main.cvd
-# COPY --from=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-av:base /var/lib/clamav/daily.cvd /var/lib/clamav/daily.cvd
-# COPY --from=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-av:base /var/lib/clamav/bytecode.cvd /var/lib/clamav/bytecode.cvd
-
-# RUN chown clamav:clamav /var/lib/clamav/*.cvd
-
 # permission juggling
 RUN mkdir /var/run/clamav && \
     chown clamav:clamav /var/run/clamav && \

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,9 +3,15 @@
 # copied from https://github.com/mko-x/docker-clamav
 
 set -m
-
+MAIN_FILE="/var/lib/clamav/main.cvd"
 # start clam service itself and the updater in background as daemon
 freshclam -d &
+echo -e "waiting for clam to update..."
+until [[ -e ${MAIN_FILE} ]]
+do
+    :
+done
+echo -e "starting clamd..."
 clamd &
 
 # start clamav update checker

--- a/deploy-eks/fb-av-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-av-chart/templates/deployment.yaml
@@ -56,3 +56,4 @@ spec:
           initialDelaySeconds: 300
           periodSeconds: 15
           successThreshold: 1
+          timeoutSeconds: 3

--- a/deploy-eks/fb-av-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-av-chart/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
         readinessProbe:
           exec:
             command:
-              - /readiness_probe.sh
+              - ./readiness_probe.sh
           initialDelaySeconds: 500
           periodSeconds: 15
           successThreshold: 1

--- a/deploy-eks/fb-av-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-av-chart/templates/deployment.yaml
@@ -50,8 +50,6 @@ spec:
         readinessProbe:
           exec:
             command:
-              # - /bin/bash
-              # - -c
               - /readiness_probe.sh
           initialDelaySeconds: 300
           periodSeconds: 15

--- a/deploy-eks/fb-av-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-av-chart/templates/deployment.yaml
@@ -50,7 +50,9 @@ spec:
         readinessProbe:
           exec:
             command:
-              - /readiness_probe.sh
+              - /bin/bash
+              - -c
+              - ./readiness_probe.sh
           initialDelaySeconds: 300
           periodSeconds: 15
           successThreshold: 1

--- a/deploy-eks/fb-av-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-av-chart/templates/deployment.yaml
@@ -50,9 +50,9 @@ spec:
         readinessProbe:
           exec:
             command:
-              - /bin/bash
-              - -c
-              - ./readiness_probe.sh
+              # - /bin/bash
+              # - -c
+              - /readiness_probe.sh
           initialDelaySeconds: 300
           periodSeconds: 15
           successThreshold: 1

--- a/deploy-eks/fb-av-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-av-chart/templates/deployment.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: "{{ .Values.namespace }}"
 spec:
   replicas: 1
+  readinessProbe:
+        exec:
+          command:
+            - /readiness_probe.sh
+        initialDelaySeconds: 500
+        periodSeconds: 15
+        successThreshold: 1
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/deploy-eks/fb-av-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-av-chart/templates/deployment.yaml
@@ -12,12 +12,12 @@ spec:
       maxSurge: 100%
       maxUnavailable: 0%
       readinessProbe:
-      exec:
-        command:
-          - /readiness_probe.sh
-      initialDelaySeconds: 500
-      periodSeconds: 15
-      successThreshold: 1
+        exec:
+          command:
+            - /readiness_probe.sh
+        initialDelaySeconds: 500
+        periodSeconds: 15
+        successThreshold: 1
   selector:
     matchLabels:
       app: "fb-av-{{ .Values.environmentName }}"

--- a/deploy-eks/fb-av-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-av-chart/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
         readinessProbe:
           exec:
             command:
-              - ./readiness_probe.sh
-          initialDelaySeconds: 500
+              - /readiness_probe.sh
+          initialDelaySeconds: 300
           periodSeconds: 15
           successThreshold: 1

--- a/deploy-eks/fb-av-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-av-chart/templates/deployment.yaml
@@ -11,13 +11,6 @@ spec:
     rollingUpdate:
       maxSurge: 100%
       maxUnavailable: 0%
-      readinessProbe:
-        exec:
-          command:
-            - /readiness_probe.sh
-        initialDelaySeconds: 500
-        periodSeconds: 15
-        successThreshold: 1
   selector:
     matchLabels:
       app: "fb-av-{{ .Values.environmentName }}"
@@ -54,3 +47,10 @@ spec:
               secretKeyRef:
                 name: fb-av-secrets-{{ .Values.environmentName }}
                 key: sentry_dsn
+        readinessProbe:
+          exec:
+            command:
+              - /readiness_probe.sh
+          initialDelaySeconds: 500
+          periodSeconds: 15
+          successThreshold: 1

--- a/deploy-eks/fb-av-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-av-chart/templates/deployment.yaml
@@ -6,18 +6,18 @@ metadata:
   namespace: "{{ .Values.namespace }}"
 spec:
   replicas: 1
-  readinessProbe:
-        exec:
-          command:
-            - /readiness_probe.sh
-        initialDelaySeconds: 500
-        periodSeconds: 15
-        successThreshold: 1
   strategy:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 100%
       maxUnavailable: 0%
+      readinessProbe:
+      exec:
+        command:
+          - /readiness_probe.sh
+      initialDelaySeconds: 500
+      periodSeconds: 15
+      successThreshold: 1
   selector:
     matchLabels:
       app: "fb-av-{{ .Values.environmentName }}"

--- a/readiness_probe.sh
+++ b/readiness_probe.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+MAIN_FILE="/var/lib/clamav/main.cvd"
+if [[ -e ${MAIN_FILE} ]]
+then
+    echo "ready"
+    exit 0
+else
+    echo "not ready"
+    exit 1
+fi


### PR DESCRIPTION
- Rotated circle secrets
- fb-av:base no longer exists, let freshclam download definitions files on startup
- wait for main definitions file before starting clamd
- wait for virus definitions before considering pod ready and rolling out
