### PR TITLE
Make the default 2 replicas for the av pods.

### DIFF
--- a/deploy-eks/fb-av-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-av-chart/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "fb-av-{{ .Values.environmentName }}"
   namespace: "{{ .Values.namespace }}"
 spec:
-  replicas: 1
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
This PR wil add an extra replica to each platform namespace and should let the fb-av pod recycle gracefully and not cause any connection errors.