### PR TITLE
Add  'checkout'  job to circleci config steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,7 @@ jobs:
   smoke_tests:
     docker: *ecr_image
     steps:
+      - checkout
       - setup_remote_docker
       - run: *deploy_scripts
       - run:


### PR DESCRIPTION
### Add 'checkout' step in circle config
Github have recently rotated their RSA SSH host key: https://github.blog/2023-03-23-we-updated-our-rsa-ssh-host-key/
As a result, the public key is no longer up to date in the `known_host` file.

The 'checkout' step automatically adds the required authenticity keys for interacting with Github. Adding this job allows the acceptance test and smoke tests steps to interact with Github.