### PR TITLE
Improve probes and adds lifecycle preStop hook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,7 @@ workflows:
             branches:
               only:
                 - master
+                - lifecycle
           requires:
             - login-to-aws
       - deploy_to_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,6 @@ workflows:
             branches:
               only:
                 - master
-                - lifecycle
           requires:
             - login-to-aws
       - deploy_to_test:

--- a/deploy-eks/fb-av-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-av-chart/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         tier: "frontend"
     spec:
       serviceAccountName: "formbuilder-av-{{ .Values.environmentName }}"
-      terminationGracePeriodSeconds: 90
+      terminationGracePeriodSeconds: 120
       containers:
       - name: "fb-av-{{ .Values.environmentName }}"
         image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-av:{{ .Values.circleSha1 }}"

--- a/deploy-eks/fb-av-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-av-chart/templates/deployment.yaml
@@ -36,11 +36,16 @@ spec:
             cpu: 150m
             memory: 3500Mi
         ports:
-          - containerPort: 3310
+          - name: clamav-port
+            containerPort: 3310
+        startupProbe:
+          tcpSocket:
+            port: clamav-port
+          failureThreshold: 30
+          periodSeconds: 15
         readinessProbe:
           tcpSocket:
-            port: 3310
-          initialDelaySeconds: 180
+            port: clamav-port
           periodSeconds: 5
         lifecycle:
           preStop:

--- a/deploy-eks/fb-av-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-av-chart/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
         tier: "frontend"
     spec:
       serviceAccountName: "formbuilder-av-{{ .Values.environmentName }}"
+      terminationGracePeriodSeconds: 90
       containers:
       - name: "fb-av-{{ .Values.environmentName }}"
         image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-av:{{ .Values.circleSha1 }}"
@@ -36,6 +37,15 @@ spec:
             memory: 3500Mi
         ports:
           - containerPort: 3310
+        readinessProbe:
+          tcpSocket:
+            port: 3310
+          initialDelaySeconds: 180
+          periodSeconds: 5
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "killall -SIGTERM clamd; while [ -S /tmp/clamd.sock ]; do sleep 1; done"]
         # non-secret env vars
         # defined in config_map.yaml
         envFrom:
@@ -47,10 +57,3 @@ spec:
               secretKeyRef:
                 name: fb-av-secrets-{{ .Values.environmentName }}
                 key: sentry_dsn
-        readinessProbe:
-          exec:
-            command: ["clamdscan", "--ping", "1"]
-          initialDelaySeconds: 180
-          periodSeconds: 15
-          successThreshold: 1
-          timeoutSeconds: 3


### PR DESCRIPTION
Added a startup probe. This probe disables other probes until it is successful, then other probes take over and the startup probe stops.
Useful as the period can be increased (15s) in the startup probe and then reduced (5s) in the readiness.

Changed the readiness probe from using the `clamdscan` ping command to use `tcpSocket`. It has the same effect but is simpler.

Implemented a basic preStop hook as part of the pod lifecycle to ensure we kill gracefully `clamd` before allowing the pod to be killed, to let any in-progress scans finalise.
Maximum termination grace period if the preStop hang around for too long set to 120 seconds.

All these changes have been successfully tested in test-dev/test-production.